### PR TITLE
New server jar builder task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -285,6 +285,43 @@ var minifyJsonResources = tasks.register("minifyJsonResources") {
 	}
 }
 
+tasks.register('serverJar', Jar) {
+	dependsOn(minifyJsonResources)
+	archiveClassifier.set('server')
+
+	// Extract from the reobfuscated jar and exclude client-only resources
+	// Keeps language files as they are needed for server-side translation of messages
+	from(zipTree(tasks.named('reobfJar').flatMap { it.archiveFile })) {
+		exclude 'assets/biomancy/sounds/**'
+		exclude 'assets/biomancy/models/**'
+		exclude 'assets/biomancy/animations/**'
+		exclude 'assets/biomancy/font/**'
+		exclude 'assets/biomancy/textures/**'
+		exclude 'assets/biomancy/blockstates/**'
+		exclude 'assets/biomancy/geo/**'
+		exclude 'assets/biomancy/shaders/**'
+		exclude 'assets/biomancy/tooltipoverhaul/**'
+	}
+
+
+	duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
+
+	manifest.attributes([
+			'Specification-Title'     : mod_name,
+			'Specification-Vendor'    : mod_vendor,
+			'Specification-Version'   : mod_major_version,
+			'Implementation-Title'    : project.name,
+			'Implementation-Version'  : project.jar.archiveVersion,
+			'Implementation-Vendor'   : mod_vendor,
+			'Implementation-Timestamp': new Date().format("yyyy-MM-dd'T'HH:mm:ssZ"),
+
+			"MixinConfigs"            : "${mod_id}.mixins.json"
+	])
+
+	from { ["CREDITS.md", "LICENSE.txt", "3RD_PARTY_LICENSE.txt"] } //copy files from the repository root into the jar
+
+}
+
 jar {
 	dependsOn(minifyJsonResources)
 
@@ -301,6 +338,10 @@ jar {
 	])
 
 	from { ["CREDITS.md", "LICENSE.txt", "3RD_PARTY_LICENSE.txt"] } //copy files from the repository root into the jar
+}
+// Make the build task depend on serverJar
+tasks.named('build').configure {
+	dependsOn 'serverJar'
 }
 
 // Include the output of "generateModMetadata" as an input directory for the build


### PR DESCRIPTION
I've modified the buildscript to compile a server-oriented build of Biomancy for server packs. The task I've added here is `serverJar`, which runs after `jar`. More of a QoL for modpack developers, since I was requested by a modpack dev to make server jars.

The server jar is a minimized version of the mod for easier uploading to remote server locations. The server jar exists as a separate artifact when compiling and building Biomancy, and can be uploaded as an additional file on Curseforge & Modrinth in the next update (or current one.) It excludes files such as sounds and textures, but not any assets that _are_ utilized by the server, such as language files and `sounds.json`.

I didn't see a huge improvement as the impact is much more significant in larger mods, I did see it make a ~3.9 MB server jar while the main jar (client+server jar) was~ 6.5 MB. Might be slightly inaccurate considering these are metrics from EXT4 (Linux) drive formatting and not NTFS (Windows), but seeing nearly 50% filesize reduction is still a good metric.
<img width="750" height="85" alt="image" src="https://github.com/user-attachments/assets/f80a1b42-8ebd-4d62-8d9d-e6fc6d180bb0" />

Please let me know if I need to make any adjustments, I kept the extra licensing files included in the server jar as well as any metadata.